### PR TITLE
BLD: Macos x86 build without metal

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,9 +21,15 @@ build_llamacpp() {
 		cp examples/llava/*.h ${INCLUDE} && \
 		cd build
   if [[ -z "${XLLAMACPP_BUILD_CUDA}" ]]; then
-    cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib && \
-    cmake --build . --config Release && \
-    cmake --install . --prefix ${PREFIX}
+	if [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "x86_64" ]]; then
+		cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DGGML_METAL=OFF && \
+		cmake --build . --config Release && \
+		cmake --install . --prefix ${PREFIX}
+	else
+		cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib && \
+		cmake --build . --config Release && \
+		cmake --install . --prefix ${PREFIX}
+	fi
   else
     cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DGGML_CUDA=ON && \
     cmake --build . --config Release && \


### PR DESCRIPTION
Macos x86 with metal runs error:
```
ggml_metal_init: allocating
ggml_metal_init: found device: Apple Paravirtual device
ggml_metal_init: picking default device: Apple Paravirtual device
ggml_metal_init: using embedded metal library
ggml_metal_init: error: Error Domain=MTLLibraryErrorDomain Code=3 "program_source:2765:9: error: invalid type 'const constant ggml_metal_kargs_bin &' for buffer declaration
        constant ggml_metal_kargs_bin & args,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
program_source:1902:5: note: type 'uint64_t' (aka 'unsigned long') cannot be used in buffer pointee type
    uint64_t nb00;
    ^
program_source:1903:5: note: type 'uint64_t' (aka 'unsigned long') cannot be used in buffer pointee type
    uint64_t nb01;
    ^
program_source:1904:5: note: type 'uint64_t' (aka 'unsigned long') cannot be used in buffer pointee type
    uint64_t nb02;
    ^
```