### PR TITLE
BLD: Disable GGML_METAL_USE_BF16

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,7 +32,7 @@ build_llamacpp() {
 			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-blas ggml-cpu mtmd_static
 		else
 			echo "Building for Apple Silicon"
-			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_RPATH="@loader_path" -DGGML_METAL_USE_BF16=ON -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_CURL=OFF && \
+			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_RPATH="@loader_path" -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_CURL=OFF && \
 			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-blas ggml-cpu ggml-metal mtmd_static
 		fi
 	else


### PR DESCRIPTION
`-DGGML_METAL_USE_BF16=ON` may cause a crash in Conda Python. (a locally compiled Python build is fine). We disable `GGML_METAL_USE_BF16` for max compatibility.

```python
Python 3.12.7 | packaged by Anaconda, Inc. | (main, Oct  4 2024, 08:22:19) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import xllamacpp
>>> xllamacpp.get_device_info()
-[MTLComputePipelineDescriptorInternal setComputeFunction:withType:]:800: failed assertion `computeFunction must not be nil.'
[1]    25003 abort      python
```