### PR TITLE
ENH: Support passing CMAKE_ARGS to make

### DIFF
--- a/.github/workflows/build-wheel-cuda-hip.yaml
+++ b/.github/workflows/build-wheel-cuda-hip.yaml
@@ -280,18 +280,7 @@ jobs:
           # Export build variables
           export XLLAMACPP_BUILD_CUDA=1
           export VERSIONEER_CLOSEST_TAG_ONLY=1
-          export VERBOSE=1
-          export CMAKE_ARGS="-DGGML_CUDA=on \
-            -DCMAKE_CUDA_ARCHITECTURES=all \
-            -DGGML_CUDA_FORCE_MMQ=ON \
-            -DGGML_AVX2=off \
-            -DGGML_FMA=off \
-            -DGGML_F16C=off \
-            -DCUDAToolkit_ROOT=$CONDA_PREFIX \
-            -DCMAKE_CUDA_COMPILER=$CONDA_PREFIX/bin/nvcc"
-          
-          echo "=== CMake Configuration ==="
-          echo "CMAKE_ARGS: $CMAKE_ARGS"
+          export VERBOSE=1S
           
           make
           python -m build --wheel
@@ -373,8 +362,7 @@ jobs:
           export XLLAMACPP_BUILD_CUDA=1
           export VERSIONEER_CLOSEST_TAG_ONLY=1
           export VERBOSE=1
-          export CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=all -DGGML_CUDA_FORCE_MMQ=ON -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off"
-          
+                    
           make
           python -m build --wheel
           

--- a/.github/workflows/build-wheel-cuda-hip.yaml
+++ b/.github/workflows/build-wheel-cuda-hip.yaml
@@ -347,6 +347,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install build wheel delvewheel
+          python -m pip install -r requirements.txt
 
       - name: Download and install win64devkit
         run: |

--- a/.github/workflows/build-wheel-cuda-hip.yaml
+++ b/.github/workflows/build-wheel-cuda-hip.yaml
@@ -299,10 +299,10 @@ jobs:
           auditwheel show dist/*.whl
           
           if [ "${{ matrix.platform }}" = "ubuntu-22.04-arm" ]; then
-            auditwheel repair --plat manylinux_2_35_aarch64 --exclude libcuda.so.1 dist/*.whl -w dist
+            auditwheel repair --plat manylinux_2_39_aarch64 --exclude libcuda.so.1 dist/*.whl -w dist
             rm -f dist/*-linux_aarch64.whl
           else
-            auditwheel repair --plat manylinux_2_35_x86_64 --exclude libcuda.so.1 dist/*.whl -w dist
+            auditwheel repair --plat manylinux_2_39_x86_64 --exclude libcuda.so.1 dist/*.whl -w dist
             rm -f dist/*-linux_x86_64.whl
           fi
           
@@ -325,7 +325,7 @@ jobs:
         cuda: ["12.4.1", "12.8.1"]
     defaults:
       run:
-        shell: pwsh
+        shell: bash
     env:
       CUDAVER: ${{ matrix.cuda }}
 
@@ -351,11 +351,11 @@ jobs:
       - name: Download and install win64devkit
         run: |
           curl -L https://github.com/skeeto/w64devkit/releases/download/v1.22.0/w64devkit-1.22.0.zip --output w64devkit.zip
-          Expand-Archive w64devkit.zip -DestinationPath .
+          unzip -q w64devkit.zip -d .
 
       - name: Add w64devkit to PATH
         run: |
-          echo "$(Get-Location)\w64devkit\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "$(pwd)/w64devkit/bin" >> $GITHUB_PATH
 
       - name: Setup CUDA
         uses: Jimver/cuda-toolkit@v0.2.24
@@ -366,16 +366,21 @@ jobs:
 
       - name: Build Wheel
         run: |
-          $cudaVersion = $env:CUDAVER.Remove($env:CUDAVER.LastIndexOf('.')).Replace('.','')
-          $env:XLLAMACPP_BUILD_CUDA = 1
-          $env:VERSIONEER_CLOSEST_TAG_ONLY = 1
-          $env:CMAKE_ARGS = '-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=all -DGGML_CUDA_FORCE_MMQ=ON -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off'
+          cuda_version=${CUDAVER//./}
+          cuda_version=${cuda_version:0:${#cuda_version}-1}
+          
+          export XLLAMACPP_BUILD_CUDA=1
+          export VERSIONEER_CLOSEST_TAG_ONLY=1
+          export VERBOSE=1
+          export CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=all -DGGML_CUDA_FORCE_MMQ=ON -DGGML_AVX2=off -DGGML_FMA=off -DGGML_F16C=off"
           
           make
           python -m build --wheel
-          delvewheel repair --exclude nvcuda.dll dist/*.whl -w dist
           
-          Write-Output "CUDA_VERSION=$cudaVersion" >> $env:GITHUB_ENV
+          # On Windows, we use delvewheel for wheel repair
+          python -m delvewheel repair --exclude nvcuda.dll dist/*.whl -w dist
+          
+          echo "CUDA_VERSION=$cuda_version" >> $GITHUB_ENV
 
       - uses: softprops/action-gh-release@v2
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -148,7 +148,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD_LINUX: apt install -y libopenblas-dev && pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD_LINUX: apt-get install -y libopenblas-dev && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -150,7 +150,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
           CIBW_BEFORE_BUILD_LINUX: yum install -y openblas-devel && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel show {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --plat manylinux_2_31_x86_64 -w {dest_dir} {wheel}
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -148,7 +148,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD_LINUX: sudo apt-get update && sudo apt-get install -y libopenblas-dev && pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD_LINUX: yum install -y openblas-devel && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -150,6 +150,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
           CIBW_BEFORE_BUILD_LINUX: yum install -y openblas-devel && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel show {wheel}
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -148,7 +148,8 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD: sudo apt-get update && sudo apt-get install -y libopenblas-dev && pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD_LINUX: sudo apt-get update && sudo apt-get install -y libopenblas-dev && pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -148,9 +148,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD_LINUX: yum install -y openblas-devel && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --plat manylinux_2_31_x86_64 -w {dest_dir} {wheel}
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -148,7 +148,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD_LINUX: yum install -y openblas-devel && pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD_LINUX: apt install -y libopenblas-dev && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -148,7 +148,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD: sudo apt-get update && sudo apt-get install -y libopenblas-dev && pip install -r requirements.txt && make
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"
         with:

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -141,14 +141,14 @@ jobs:
           vs-version: '[17.13,17.14)'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           VERSIONEER_CLOSEST_TAG_ONLY: 1
           CIBW_SKIP: pp* *i686
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.requires-python }}
           CIBW_TEST_REQUIRES: pytest requests pytest-asyncio pytest-timeout
-          CIBW_BEFORE_BUILD_LINUX: apt-get install -y libopenblas-dev && pip install -r requirements.txt && make
+          CIBW_BEFORE_BUILD_LINUX: yum install -y openblas-devel && pip install -r requirements.txt && make
           CIBW_BEFORE_BUILD: pip install -r requirements.txt && make
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT: "XLLAMACPP_BUILD_AARCH64=${{ matrix.arch == 'aarch64' && '1' || '' }}"

--- a/.github/workflows/build-wheel.yaml
+++ b/.github/workflows/build-wheel.yaml
@@ -141,7 +141,7 @@ jobs:
           vs-version: '[17.13,17.14)'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.3
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           VERSIONEER_CLOSEST_TAG_ONLY: 1
           CIBW_SKIP: pp* *i686

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,7 +26,7 @@ build_llamacpp() {
 	cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu ggml-hip mtmd
   elif [[ -n "${XLLAMACPP_BUILD_AARCH64}" ]]; then
 	echo "Building for aarch64"
-	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a && \
+	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS && \
 	cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
   else
 	if [[ "$(uname -s)" == "Darwin" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,35 +16,65 @@ build_llamacpp() {
 	cd ${PROJECT} && \
 		mkdir -p build &&
 		cd build
-  if [[ -n "${XLLAMACPP_BUILD_CUDA}" ]]; then
-  	echo "Building for CUDA"
-	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CUDA=ON -DGGML_CUDA_FORCE_MMQ=ON && \
-    cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu ggml-cuda mtmd
-  elif [[ -n "${XLLAMACPP_BUILD_HIP}" ]]; then
-	echo "Building for AMD GPU"
-	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DAMDGPU_TARGETS="gfx1100;gfx1101;gfx1102;gfx1030;gfx1031;gfx1032" -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" -DGGML_HIP_ROCWMMA_FATTN=ON -DGGML_HIP=ON && \
-	cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu ggml-hip mtmd
-  elif [[ -n "${XLLAMACPP_BUILD_AARCH64}" ]]; then
-	echo "Building for aarch64"
-	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a && \
-	cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
-  else
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		if [[ "$(uname -m)" == "x86_64" ]]; then
-			echo "Building for Intel"
-			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_RPATH="@loader_path" -DLLAMA_CURL=OFF -DGGML_METAL=OFF && \
-			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-blas ggml-cpu mtmd
-		else
-			echo "Building for Apple Silicon"
-			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_RPATH="@loader_path" -DGGML_METAL_EMBED_LIBRARY=ON -DLLAMA_CURL=OFF && \
-			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-blas ggml-cpu ggml-metal mtmd
-		fi
-	else
-		echo "Building for non-MacOS CPU (optimize for native CPU)"
-		cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF && \
-		cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
-	fi
+  # Base CMake arguments
+  CMAKE_ARGS=(
+    "-DBUILD_SHARED_LIBS=OFF"
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+    "-DLLAMA_CURL=OFF"
+  )
+  
+  # Add any additional CMake arguments from environment
+  if [ -n "${CMAKE_ARGS}" ]; then
+    CMAKE_ARGS+=(${CMAKE_ARGS})
   fi
+
+  # Build targets
+  TARGETS=("common" "llama" "ggml" "ggml-cpu" "mtmd")
+  
+  if [[ -n "${XLLAMACPP_BUILD_CUDA}" ]]; then
+    echo "Building for CUDA"
+    CMAKE_ARGS+=("-DGGML_NATIVE=OFF" "-DGGML_CUDA=ON" "-DGGML_CUDA_FORCE_MMQ=ON")
+    TARGETS+=("ggml-cuda")
+  elif [[ -n "${XLLAMACPP_BUILD_HIP}" ]]; then
+    echo "Building for AMD GPU"
+    CMAKE_ARGS+=(
+      "-DGGML_NATIVE=OFF"
+      "-DAMDGPU_TARGETS=gfx1100;gfx1101;gfx1102;gfx1030;gfx1031;gfx1032"
+      "-DCMAKE_HIP_COMPILER=$(hipconfig -l)/clang"
+      "-DGGML_HIP_ROCWMMA_FATTN=ON"
+      "-DGGML_HIP=ON"
+    )
+    TARGETS+=("ggml-hip")
+  elif [[ -n "${XLLAMACPP_BUILD_AARCH64}" ]]; then
+    echo "Building for aarch64"
+    CMAKE_ARGS+=("-DGGML_NATIVE=OFF" "-DGGML_CPU_ARM_ARCH=armv8-a")
+  else
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      CMAKE_ARGS+=("-DCMAKE_BUILD_RPATH=@loader_path")
+      if [[ "$(uname -m)" == "x86_64" ]]; then
+        echo "Building for Intel"
+        CMAKE_ARGS+=("-DGGML_METAL=OFF")
+        TARGETS+=("ggml-blas")
+      else
+        echo "Building for Apple Silicon"
+        CMAKE_ARGS+=("-DGGML_METAL_EMBED_LIBRARY=ON")
+        TARGETS+=("ggml-blas" "ggml-metal")
+      fi
+    else
+      echo "Building for non-MacOS CPU (optimize for native CPU)"
+      # Check if BLAS is enabled in CMake args
+      if [[ " ${CMAKE_ARGS[*]} " =~ " -DGGML_BLAS=ON " ]]; then
+        echo "BLAS is enabled, adding ggml-blas to build targets"
+        TARGETS+=("ggml-blas")
+      fi
+    fi
+  fi
+
+  # Run CMake and build
+  cmake .. "${CMAKE_ARGS[@]}" && \
+  # Build all targets in one command
+  cmake --build . --config Release -j ${NPROC} --target ${TARGETS[*]}
   rm -rf ${PREFIX}
   python ${CWD}/scripts/copy_libs.py
   cd ${CWD}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,7 +26,7 @@ build_llamacpp() {
 	cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu ggml-hip mtmd
   elif [[ -n "${XLLAMACPP_BUILD_AARCH64}" ]]; then
 	echo "Building for aarch64"
-	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS && \
+	cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a && \
 	cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
   else
 	if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -41,14 +41,8 @@ build_llamacpp() {
 		fi
 	else
 		echo "Building for non-MacOS CPU (optimize for native CPU)"
-		if [[ "$(uname -s)" == "Linux" ]]; then
-			echo "Enabling OpenBLAS for Linux"
-			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS && \
-			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu ggml-blas mtmd
-		else
-			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF && \
-			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
-		fi
+		cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF && \
+		cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
 	fi
   fi
   rm -rf ${PREFIX}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,6 +24,11 @@ build_llamacpp() {
     "-DLLAMA_CURL=OFF"
   )
 
+  # Add any additional CMake arguments from environment
+  if [ -n "${CMAKE_ARGS}" ]; then
+    cmake_args+=(${CMAKE_ARGS})
+  fi
+
   # Build targets
   local targets=("common" "llama" "ggml" "ggml-cpu" "mtmd")
   
@@ -51,6 +56,11 @@ build_llamacpp() {
       "-DGGML_NATIVE=OFF"
       "-DGGML_CPU_ARM_ARCH=armv8-a"
     )
+    # Add ggml-blas target if BLAS is enabled via CMAKE_ARGS
+    if [[ "${CMAKE_ARGS:-}" == *"-DGGML_BLAS=ON"* ]]; then
+      echo "BLAS is enabled via CMAKE_ARGS, adding ggml-blas to build targets"
+      targets+=("ggml-blas")
+    fi
   else
     if [[ "$(uname -s)" == "Darwin" ]]; then
       cmake_args+=("-DCMAKE_BUILD_RPATH=@loader_path")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,8 +41,14 @@ build_llamacpp() {
 		fi
 	else
 		echo "Building for non-MacOS CPU (optimize for native CPU)"
-		cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF && \
-		cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
+		if [[ "$(uname -s)" == "Linux" ]]; then
+			echo "Enabling OpenBLAS for Linux"
+			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF -DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS && \
+			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu ggml-blas mtmd
+		else
+			cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_LIBDIR=lib -DLLAMA_CURL=OFF && \
+			cmake --build . --config Release -j ${NPROC} --target common llama ggml ggml-cpu mtmd
+		fi
 	fi
   fi
   rm -rf ${PREFIX}

--- a/setup.py
+++ b/setup.py
@@ -101,16 +101,16 @@ if PLATFORM == "Darwin":
             "-framework MetalKit",
         ]
     )
+    # Both the Intel and ARM platforms need to be linked with BLAS.
+    EXTRA_OBJECTS.extend(
+        [
+            f"{LLAMACPP_LIBS_DIR}/libggml-blas.a",
+        ]
+    )
     if platform.processor() == "arm":
         EXTRA_OBJECTS.extend(
             [
                 f"{LLAMACPP_LIBS_DIR}/libggml-metal.a",
-            ]
-        )
-    else:
-        EXTRA_OBJECTS.extend(
-            [
-                f"{LLAMACPP_LIBS_DIR}/libggml-blas.a",
             ]
         )
 elif PLATFORM == "Linux":

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,10 @@ if PLATFORM == "Darwin":
         )
 elif PLATFORM == "Linux":
     EXTRA_LINK_ARGS.extend(["-fopenmp", "-static-libgcc"])
+    # Check if BLAS is enabled in environment
+    if os.environ.get("CMAKE_ARGS", "").find("-DGGML_BLAS=ON") != -1:
+        print("BLAS is enabled, adding ggml-blas to link targets")
+        EXTRA_OBJECTS.extend([f"{LLAMACPP_LIBS_DIR}/libggml-blas.a"])
 
 INCLUDE_DIRS.append(os.path.join(CWD, "src/xllamacpp"))
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ else:
             f"{LLAMACPP_LIBS_DIR}/libggml.a",
             f"{LLAMACPP_LIBS_DIR}/libggml-base.a",
             f"{LLAMACPP_LIBS_DIR}/libggml-cpu.a",
-            f"{LLAMACPP_LIBS_DIR}/libggml-blas.a",
             f"{LLAMACPP_LIBS_DIR}/libmtmd.a",
         ]
     )
@@ -106,6 +105,12 @@ if PLATFORM == "Darwin":
         EXTRA_OBJECTS.extend(
             [
                 f"{LLAMACPP_LIBS_DIR}/libggml-metal.a",
+            ]
+        )
+    else:
+        EXTRA_OBJECTS.extend(
+            [
+                f"{LLAMACPP_LIBS_DIR}/libggml-blas.a",
             ]
         )
 elif PLATFORM == "Linux":

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ else:
             f"{LLAMACPP_LIBS_DIR}/libggml.a",
             f"{LLAMACPP_LIBS_DIR}/libggml-base.a",
             f"{LLAMACPP_LIBS_DIR}/libggml-cpu.a",
+            f"{LLAMACPP_LIBS_DIR}/libggml-blas.a",
             f"{LLAMACPP_LIBS_DIR}/libmtmd.a",
         ]
     )
@@ -90,24 +91,8 @@ else:
         )
         LIBRARY_DIRS.extend(["/opt/rocm/lib"])
         LIBRARIES.extend(["amdhip64", "hipblas", "rocblas"])
-if PLATFORM == "Darwin":
-    EXTRA_OBJECTS.extend(
-        [
-            f"{LLAMACPP_LIBS_DIR}/libggml-blas.a",
-        ]
-    )
-    if platform.processor() == "arm":
-        EXTRA_OBJECTS.extend(
-            [
-                f"{LLAMACPP_LIBS_DIR}/libggml-metal.a",
-            ]
-        )
-
-INCLUDE_DIRS.append(os.path.join(CWD, "src/xllamacpp"))
 
 if PLATFORM == "Darwin":
-    # EXTRA_LINK_ARGS.append("-mmacosx-version-min=11")
-    # add local rpath
     EXTRA_LINK_ARGS.append("-Wl,-rpath," + LLAMACPP_LIBS_DIR)
     os.environ["LDFLAGS"] = " ".join(
         [
@@ -117,9 +102,16 @@ if PLATFORM == "Darwin":
             "-framework MetalKit",
         ]
     )
+    if platform.processor() == "arm":
+        EXTRA_OBJECTS.extend(
+            [
+                f"{LLAMACPP_LIBS_DIR}/libggml-metal.a",
+            ]
+        )
+elif PLATFORM == "Linux":
+    EXTRA_LINK_ARGS.extend(["-fopenmp", "-static-libgcc"])
 
-if PLATFORM == "Linux":
-    EXTRA_LINK_ARGS.extend(["-fopenmp", "-static-libgcc", "-static-libstdc++"])
+INCLUDE_DIRS.append(os.path.join(CWD, "src/xllamacpp"))
 
 
 def mk_extension(name, sources, define_macros=None):


### PR DESCRIPTION
- Support passing CMAKE_ARGS to make, for example, to enable the GGML_BLAS during build: `CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" make`
- Dynamic link libstdc++ on Linux.