### PR TITLE
BUG: Fix packaging.version.InvalidVersion

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1402,6 +1402,7 @@ def git_pieces_from_vcs(
                                % (full_tag, tag_prefix))
             return pieces
         pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = pieces["closest-tag"].split("-")[0]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))


### PR DESCRIPTION
When an editable build is created using `pip install -e .`, versioneer may retrieve an invalid version number from a release tag name, such as 0.1.25-cu124+0.g184a3ac.dirty.

```python
    File "/tmp/pip-build-env-i95ze9_r/overlay/lib/python3.11/site-packages/setuptools/_vendor/packaging/version.py", line 202, in __init__
      raise InvalidVersion(f"Invalid version: {version!r}")
  packaging.version.InvalidVersion: Invalid version: '0.1.25-cu124+0.g184a3ac.dirty'
```