### PR TITLE
BUG: pip install -e . may not link libggml-blas.a

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ if PLATFORM == "Darwin":
 elif PLATFORM == "Linux":
     EXTRA_LINK_ARGS.extend(["-fopenmp", "-static-libgcc"])
     # Check if BLAS is enabled in environment
-    if os.environ.get("CMAKE_ARGS", "").find("-DGGML_BLAS=ON") != -1:
+    if os.path.exists(f"{LLAMACPP_LIBS_DIR}/libggml-blas.a"):
         print("BLAS is enabled, adding ggml-blas to link targets")
         EXTRA_OBJECTS.extend([f"{LLAMACPP_LIBS_DIR}/libggml-blas.a"])
 

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ elif PLATFORM == "Linux":
     if os.path.exists(f"{LLAMACPP_LIBS_DIR}/libggml-blas.a"):
         print("BLAS is enabled, adding ggml-blas to link targets")
         EXTRA_OBJECTS.extend([f"{LLAMACPP_LIBS_DIR}/libggml-blas.a"])
+        EXTRA_LINK_ARGS.extend(["-lopenblas"])
 
 INCLUDE_DIRS.append(os.path.join(CWD, "src/xllamacpp"))
 


### PR DESCRIPTION
If run `CMAKE_ARGS="-DGGML_BLAS=ON -DGGML_BLAS_VENDOR=OpenBLAS" make` first, followed by `pip install -e . --verbose`, the setup.py can't find the CMAKE_ARGS from the env, resulting in the output not linking libggml-blas.a

This PR ensures that setup.py does not rely on the CMAKE_ARGS environment variable.