### PR TITLE
ENH: Respect verbosity

### DIFF
--- a/src/xllamacpp/server.cpp
+++ b/src/xllamacpp/server.cpp
@@ -3968,6 +3968,7 @@ struct server_context {
 
 static void init(common_params &params, server_context &ctx_server,
                  std::promise<int> out) {
+  common_log_set_verbosity_thold(params.verbosity);
   common_init();
 
   llama_backend_init();


### PR DESCRIPTION
The verbosity was not passed to the common logs, this PR makes the verbosity work well.