### PR TITLE
BUG: Fix estimate_gpu_layers

### DIFF
--- a/src/xllamacpp/memory.py
+++ b/src/xllamacpp/memory.py
@@ -74,7 +74,7 @@ class MemoryEstimate:
     # The total size of the model if loaded into VRAM.  If all layers are loaded, vram_size == total_size
     total_size: int
     # For multi-GPU scenarios, this provides the tensor split parameter
-    tensor_split: str
+    tensor_split: list[float]
     # For multi-GPU scenarios, this is the size in bytes per GPU
     gpu_sizes: list[int]
 
@@ -427,16 +427,12 @@ def estimate_gpu_layers(
     memory_required_partial = sum(gpu_allocations)
     memory_required_total = memory_required_partial + overflow
 
-    tensor_split = ""
-    if len(gpus) > 1:
-        tensor_split = ",".join(str(c) for c in layer_counts)
-
     estimate = MemoryEstimate(
         layers=0,
         graph=0,
         vram_size=0,
         total_size=int(memory_required_total),
-        tensor_split="",
+        tensor_split=layer_counts,
         gpu_sizes=[],
     )
     if gpus[0]["name"] == "CPU":
@@ -448,6 +444,6 @@ def estimate_gpu_layers(
     estimate.graph = int(graph_offload)
     estimate.vram_size = int(memory_required_partial)
     estimate.total_size = int(memory_required_total)
-    estimate.tensor_split = tensor_split
+    estimate.tensor_split = layer_counts
     estimate.gpu_sizes = [int(i) for i in gpu_allocations]
     return estimate

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -95,7 +95,7 @@ def test_estimate_gpu_layers():
             kv_cache_type="",
         )
         assert s.expect0 + s.expect1 == estimate.layers
-        assert f"{s.expect0},{s.expect1}" == estimate.tensor_split
+        assert [s.expect0, s.expect1] == estimate.tensor_split
         layer_sums = sum(estimate.gpu_sizes)
         if estimate.layers < 6:
             assert estimate.vram_size < estimate.total_size


### PR DESCRIPTION
```python
2025-08-11 19:11:35,060 xinference.model.llm.llama_cpp.core 14974 ERROR    Estimate num gpu layers for llama.cpp backend failed: Argument 'value' has incorrect type (expected list, got str)
Traceback (most recent call last):
  File "/home/admin/workspace/inference/xinference/model/llm/llama_cpp/core.py", line 211, in load
    params.tensor_split = estimate.tensor_split
    ^^^^^^^^^^^^^^^^^^^
TypeError: Argument 'value' has incorrect type (expected list, got str)
```