### PR TITLE
BUG: Fix CUDA error: device kernel image is invalid

### DIFF
--- a/.github/workflows/build-wheel-cuda-hip.yaml
+++ b/.github/workflows/build-wheel-cuda-hip.yaml
@@ -225,7 +225,7 @@ jobs:
           fi
           
           # Install build dependencies
-          python -m pip install build wheel auditwheel
+          python -m pip install build wheel
           python -m pip install -r requirements.txt
           
           # Verify CUDA installation
@@ -284,16 +284,6 @@ jobs:
           
           make
           python -m build --wheel
-
-          auditwheel show dist/*.whl
-          
-          if [ "${{ matrix.platform }}" = "ubuntu-22.04-arm" ]; then
-            auditwheel repair --plat manylinux_2_39_aarch64 --exclude libcuda.so.1 dist/*.whl -w dist
-            rm -f dist/*-linux_aarch64.whl
-          else
-            auditwheel repair --plat manylinux_2_39_x86_64 --exclude libcuda.so.1 dist/*.whl -w dist
-            rm -f dist/*-linux_x86_64.whl
-          fi
           
           echo "CUDA_VERSION=$cuda_version" >> $GITHUB_ENV
 


### PR DESCRIPTION
On some Linux machines, running the CUDA release wheel package may trigger a CUDA error: device kernel image is invalid. This is mainly because when building the Linux CUDA release package, auditwheel was used, which bundles the dependent CUDA libraries into the wheel. However, the CUDA libraries must match the GPU driver version, and even minor mismatches in the driver version on certain machines can cause this error.

This PR removes the auditwheel step for Linux CUDA packages. As a result, when import xllamacpp is executed, it will attempt to locate and load the CUDA libraries from the system instead. The system’s built-in CUDA libraries are usually matched to the GPU driver, which provides better compatibility.

This change does not seem applicable to Windows. Since there is no environment available for testing, the Windows CUDA packages and all HIP packages for all platforms remain unchanged.