### PR TITLE
FEAT: Support rerank

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/llama.cpp"]
 	path = thirdparty/llama.cpp
-	url = git@github.com:ggml-org/llama.cpp.git
+	url = https://github.com/ggml-org/llama.cpp.git

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ $(MODEL):
 		curl --output Llama-3.2-1B-Instruct-Q8_0.gguf -L https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q8_0.gguf && \
 		curl --output tinygemma3-Q8_0.gguf -L https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/tinygemma3-Q8_0.gguf && \
 		curl --output mmproj-tinygemma3.gguf -L https://huggingface.co/ggml-org/tinygemma3-GGUF/resolve/main/mmproj-tinygemma3.gguf && \
-		curl --output Qwen3-Embedding-0.6B-Q8_0.gguf -L https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
+		curl --output Qwen3-Embedding-0.6B-Q8_0.gguf -L https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf && \
+		curl --output Qwen3-Reranker-0.6B-Q8_0.gguf -L https://huggingface.co/mradermacher/Qwen3-Reranker-0.6B-GGUF/resolve/main/Qwen3-Reranker-0.6B.Q8_0.gguf && \
+		curl --output bge-reranker-v2-m3-Q8_0.gguf -L https://modelscope.cn/models/gpustack/bge-reranker-v2-m3-GGUF/resolve/master/bge-reranker-v2-m3-Q8_0.gguf
 
 download: $(MODEL)
 	@echo "minimal model downloaded to models directory"

--- a/src/xllamacpp/server.h
+++ b/src/xllamacpp/server.h
@@ -23,6 +23,8 @@ public:
 
   std::string handle_embeddings(const std::string &input_json_str);
 
+  std::string handle_rerank(const std::string &input_json_str);
+
   void handle_completions(const std::string &prompt_json_str,
                           Callback res_error, void *py_cb_error,
                           Callback res_ok, void *py_cb_ok);

--- a/src/xllamacpp/server.pxd
+++ b/src/xllamacpp/server.pxd
@@ -18,6 +18,8 @@ cdef extern from "server.h" namespace "xllamacpp" nogil:
 
         std_string handle_embeddings(const std_string &input_json_str) except +
 
+        std_string handle_rerank(const std_string &input_json_str) except +
+
         void handle_completions(const std_string &prompt_json_str,
                 Callback res_error,
                 void *py_cb_error,

--- a/src/xllamacpp/xllamacpp.pyx
+++ b/src/xllamacpp/xllamacpp.pyx
@@ -2173,6 +2173,13 @@ cdef class Server:
         with nogil:
             result = self.svr.get().handle_embeddings(prompt_json_string)
         return json.loads(<bytes>result)
+    
+    def handle_rerank(self, dict prompt_dict):
+        cdef string result
+        cdef string prompt_json_string = json.dumps(prompt_dict)
+        with nogil:
+            result = self.svr.get().handle_rerank(prompt_json_string)
+        return json.loads(<bytes>result)
 
     def handle_completions(self, dict prompt_dict, callback=None):
         cdef string prompt_json_string = json.dumps(prompt_dict)


### PR DESCRIPTION
The original intention was to add support for Qwen3-Reranker gguf format in xinference.  However, it was found that llama.cpp's support for Qwen3-Reranker was not yet complete.
For the time being, bge-reranker-v2-m3 was used for testing. 
More discussion on llama.cpp's support for Qwen3-Reranker can be found [here](https://huggingface.co/Mungert/Qwen3-Reranker-4B-GGUF/discussions/1), and llama.cpp is also working on supporting qwen3 rerank, see [here](https://github.com/ggml-org/llama.cpp/pull/14029).